### PR TITLE
Fix bug: path.join is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ exports.handler = async (event, context, callback) => {
         mobile = false
       } = event.queryStringParameters || {}
 
-    const path = event.path.replace(/^\//, "")
-    const url = path.join(process.env.HOST, path.replace('.jpeg', ''))
+    const eventPath = event.path.replace(/^\//, "")
+    const url = path.join(process.env.HOST, eventPath.replace('.jpeg', ''))
 
     let slsChrome = null;   
     let browser = null;


### PR DESCRIPTION
Local variable `path` have the same name to the imported module.
And the following error occurs:

```json
{
    "errorType": "TypeError",
    "errorMessage": "path.join is not a function",
    "stack": [
        "TypeError: path.join is not a function",
        "    at Runtime.exports.handler (/var/task/index.js:15:22)",
        "    at Runtime.handleOnce (/var/runtime/Runtime.js:66:25)"
    ]
}
```

So, I've renamed it's name to `eventPath`.